### PR TITLE
update user agent string to follow conventions ':' => '/'

### DIFF
--- a/airflow_provider_azure_machinelearning/hooks/machine_learning.py
+++ b/airflow_provider_azure_machinelearning/hooks/machine_learning.py
@@ -126,4 +126,4 @@ class AzureMachineLearningHook(BaseHook):
         """Returns python package_name:version"""
         from airflow_provider_azure_machinelearning.__init__ import get_package_name, get_package_version
 
-        return f"{get_package_name()}:{get_package_version()}"
+        return f"{get_package_name()}/{get_package_version()}"

--- a/tests/hooks/test_machine_learning.py
+++ b/tests/hooks/test_machine_learning.py
@@ -126,7 +126,7 @@ class TestAzureMachineLearningHook(unittest.TestCase):
         from airflow_provider_azure_machinelearning.__init__ import get_package_name, get_package_version
 
         assert (
-            f"{get_package_name()}:{get_package_version()}"
+            f"{get_package_name()}/{get_package_version()}"
             == AzureMachineLearningHook.get_package_signature()
         )
 


### PR DESCRIPTION
AML SDK uses '/' instead of ':' to concatenate package name and version in user-agent string. 
Now, we are following that convention. 


Screen shot from local test:
![image](https://user-images.githubusercontent.com/28076103/212758063-f802d0fd-fc38-48f6-b6bf-422242dc21ed.png)
