### PR TITLE
PyPI release 20230118, package version 0.0.1b2

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Related Issue
+<!--- This project only accepts pull requests related to open issues -->
+<!--- If suggesting a new feature or change, please discuss it in an issue first -->
+<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
+<!--- Please link to the issue here: -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Screenshots (if appropriate):

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release**" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: [ "main", "release**" ]
   schedule:
     - cron: '25 15 * * 5'
 

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -2,10 +2,10 @@ name: Docker Image builds
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release**" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: [ "main", "release**" ]
 
 jobs:
 

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -2,9 +2,9 @@ name: Makefile CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release" ]
 
 jobs:
   make:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [ "main", "release**" ]
 
 jobs:
   pre-commit:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,47 @@
+name: Publish Python distributions to TestPyPI and PyPI
+
+on:
+  pull_request:
+    branches: [ "release-**" ]
+    types: [closed]
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python distributions to TestPyPI and PyPI
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install build
+        run: >-
+          python -m
+          pip install
+          build
+          --user
+
+      - name: Build a binary wheel and a source tarball
+        run: >-
+          python -m
+          build
+          --sdist
+          --wheel
+          --outdir dist/
+          .
+
+      - name: Publish distribution to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+
+When you submit a pull request, a CLA bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the Microsoft Open Source Code of Conduct. For more information see the Code of Conduct FAQ or contact opencode@microsoft.com with any additional questions or comments.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In you Apache Airflow instance, run:
 ```
 pip install airflow-provider-azure-machinelearning
 ```
-Or, try it out by following examples in the [dev folder](dev/), or Airflow's [How-to-Guide](https://airflow.apache.org/docs/apache-airflow/stable/howto/docker-compose/index.html) to set up Airflow in Docker containers.
+Or, try it out by following examples in the [dev folder](https://github.com/Azure/airflow-provider-azure-machinelearning/tree/main/dev/), or Airflow's [How-to-Guide](https://airflow.apache.org/docs/apache-airflow/stable/howto/docker-compose/index.html) to set up Airflow in Docker containers.
 
 # Configure Azure Machine Learning Connections in Airflow
 
@@ -27,9 +27,9 @@ To send workload to your Azure Machine Learning workspace from Airflow, you need
 2. On Airflow web portal, navigate to ```Admin``` --> ```Connections```, and click on ```+``` to add a new connection.
 
 3. From the "Connection Type" dropdown, select "Azure Machine Learning". You should see a form like below
-   ![Alt text](resources/Airflow_AzureMachineLearning_Connection.jpg "Azure Machine Learning Connection")
+   ![](https://github.com/Azure/airflow-provider-azure-machinelearning/blob/main/resources/Airflow_AzureMachineLearning_Connection.jpg "Azure Machine Learning Connection")
 
-4. ```Connection Id```is a unique identifier for your connection. You will also need to pass this string into AzureML Airflow operators. Check out those [example dags](airflow_provider_azure_machinelearning/example_dags/).
+4. ```Connection Id```is a unique identifier for your connection. You will also need to pass this string into AzureML Airflow operators. Check out those [example dags](https://github.com/Azure/airflow-provider-azure-machinelearning/tree/main/airflow_provider_azure_machinelearning/example_dags/).
 
 5.  ```Description``` is optional. All other fields are required.
 
@@ -67,7 +67,7 @@ airflow connections add \
 ```
 # Examples
 
-Check out [example_dags](airflow_provider_azure_machinelearning/example_dags/) on how to make use of this provider package. If you do not have a running Airflow instance, please refer to [example docker containers](dev/), or [Apache Airflow documentations\)https://airflow.apache.org/).
+Check out [example_dags](https://github.com/Azure/airflow-provider-azure-machinelearning/tree/main/airflow_provider_azure_machinelearning/example_dags) on how to make use of this provider package. If you do not have a running Airflow instance, please refer to [example docker containers](https://github.com/Azure/airflow-provider-azure-machinelearning/tree/main/dev/), or [Apache Airflow documentations\)https://airflow.apache.org/).
 
 # Dev Environment
 
@@ -76,7 +76,7 @@ To build this package, run its tests, run its linting tools, etc, you will need 
 - Via conda: ```conda env create -f dev/environment.yml```
 
 # Running the tests and linters
-- All tests are in [tests](tests) folder. To run them, from this folder, run ```pytest```
+- All tests are in [tests](https://github.com/Azure/airflow-provider-azure-machinelearning/tree/main/tests/) folder. To run them, from this folder, run ```pytest```
 - This repo uses [black](https://github.com/psf/black), [flake8](https://github.com/PyCQA/flake8), and [isort](https://github.com/PyCQA/isort) to keep coding format consistent. From this folder, run ```black .```, ```isort .```, and ```flake8```.
 
 # Issues

--- a/airflow_provider_azure_machinelearning/__init__.py
+++ b/airflow_provider_azure_machinelearning/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.1b0"
+__version__ = "0.0.1b2"
 
 
 def get_package_name():

--- a/airflow_provider_azure_machinelearning/hooks/machine_learning.py
+++ b/airflow_provider_azure_machinelearning/hooks/machine_learning.py
@@ -126,4 +126,4 @@ class AzureMachineLearningHook(BaseHook):
         """Returns python package_name:version"""
         from airflow_provider_azure_machinelearning.__init__ import get_package_name, get_package_version
 
-        return f"{get_package_name()}:{get_package_version()}"
+        return f"{get_package_name()}/{get_package_version()}"

--- a/tests/hooks/test_machine_learning.py
+++ b/tests/hooks/test_machine_learning.py
@@ -126,7 +126,7 @@ class TestAzureMachineLearningHook(unittest.TestCase):
         from airflow_provider_azure_machinelearning.__init__ import get_package_name, get_package_version
 
         assert (
-            f"{get_package_name()}:{get_package_version()}"
+            f"{get_package_name()}/{get_package_version()}"
             == AzureMachineLearningHook.get_package_signature()
         )
 


### PR DESCRIPTION
PyPI release 20230118, package version 0.0.1b2

## Description
Changes in this release are:
- PR template
- Contriubting.md file
- User-agent string carrying package-name/package-version instead of package-name:package-version
- Fix links in read me so that it renders in the pypi homepage

## Related Issue
Included changes are shown in the screenshot below.

## Motivation and Context
This PR, when merged, tests the new PyPI release process.

## How Has This Been Tested?
The bits are tested via the integrated UT and GH workflows

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/28076103/212980787-ed067775-fd40-43ad-94a2-fe7727101120.png)
