### PR TITLE
update publishing workflow to run from triggering release branch

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@master
+        with:
+          ref: ${{ github.ref }}
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v4


### PR DESCRIPTION
Update publishing workflow to run from triggering release branch.

## Description
PyPI publishing workflow had a bug where it is running on main branch. Changing it to run from releases-* branches once merged. 

